### PR TITLE
fix #32 - fix error "cannot find module 'Q'"

### DIFF
--- a/lib/promise/install.js
+++ b/lib/promise/install.js
@@ -1,5 +1,5 @@
 var bower = require('bower'),
-    Q = require('Q'),
+    Q = require('q'),
     Plugin = require('../Plugin'),
     uninstallPackage = require('./uninstallPackage');
 


### PR DESCRIPTION
- on *nix, requirejs throws an error due to case sensitivity in paths