### PR TITLE
Travis enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,36 @@
+---
 language: node_js
 node_js:
-  - "0.11"
+  - '0.11'
+
+sudo: false
+
+branches:
+  only:
+    - master
+    - develop
+
+git:
+  depth: 10
+
+cache:
+  directories:
+    - node_modules
+
 before_script:
   - npm install -g grunt-cli
-sudo: false
+
+install:
+  - npm config set spin false
+  - npm install
+
+matrix:
+  fast_finish: true
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/2b42e20cf5f5550c1dc0
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Adapt Command Line Interface
 ============================
 
-[![Join the chat at https://gitter.im/adaptlearning/adapt-cli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/adaptlearning/adapt-cli?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build Status](https://travis-ci.org/adaptlearning/adapt-cli.png?branch=master)](https://travis-ci.org/adaptlearning/adapt-cli)
+[![Build Status](https://travis-ci.org/adaptlearning/adapt-cli.png?branch=master)](https://travis-ci.org/adaptlearning/adapt-cli)  [![Join the chat at https://gitter.im/adaptlearning/adapt-cli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/adaptlearning/adapt-cli?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Installation
 ------------
@@ -21,7 +19,7 @@ Usage
 
     adapt create {type} {path} [{branch}]
 
-type - What to create. Only the value "course" is currently supported. 
+type - What to create. Only the value "course" is currently supported.
 path - The directory of the new course.
 branch - Optional - The branch of the framework to be downlaoded.
 
@@ -51,7 +49,7 @@ Therefore these commands are equivalent:
     adapt install adapt-my-plugin
     adapt install my-plugin
 
-Installed plugins are saved to `adapt.json`. 
+Installed plugins are saved to `adapt.json`.
 
 ##### Installing plugins previously saved in adapt.json
 


### PR DESCRIPTION
- now only allow to build below branch names (case sensitive) on Travis
  - master
  - develop
- now limiting to ```depth: 10``` while cloning git repository
- caching ```node_modules``` directory content
- integrating with Gitter for notifications
