### PR TITLE
added node version check and updated the licence to a correct string

### DIFF
--- a/bin/adapt
+++ b/bin/adapt
@@ -1,3 +1,14 @@
 #!/usr/bin/env node
+var chalk = require("chalk");
+var fs = require('fs');
+var path = require('path');
+var semver = require('semver');
+var curVer = process.versions.node;
+var pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
+var versRange = pkg.engines.node;
+var errString = 'adapt-cli has been tested on node versions between '+pkg.engines.node+', you are curently using ' + curVer + ' - errors may occur.';
+if(semver.satisfies(curVer, pkg.engines.node) === false){
+  console.warn(chalk.red(errString));
+}
 var cli = require('../lib/cli');
 cli.withOptions().withPackage().execute();

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
   },
   "author": "",
   "repository": "http://github.com/adaptlearning/adapt-cli",
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "bin": {
     "adapt": "./bin/adapt"
-  }
+  },
+  "engines" : { "node" : "0.10.33 - 0.10.40" }
 }


### PR DESCRIPTION
Hi there, this commit add a section to the package.json where we can define a node version range that is supported by the CLI and a check in the bin/adapt that verifies that the user node version is matching it.
Inputs are welcome on what version are supported. (currently it is limited to 0.10.33)

It also add a valid string for the licence. (GPL-3.0)