### PR TITLE
Devinstall command for cli tool

### DIFF
--- a/lib/PackageMeta.js
+++ b/lib/PackageMeta.js
@@ -26,5 +26,16 @@ module.exports = {
                 deferred.resolve(allVersions);
              });
         return deferred.promise;
+    },
+    getRepositoryUrl: function (plugin, config) {
+        var deferred = Q.defer();
+        bower.commands.lookup(plugin.toString(), config || {})
+            .on('end', function(results) {
+                deferred.resolve(results);
+            })
+            .on('error', function(err) {
+                deferred.reject(err);
+            });
+        return deferred.promise;
     }
 };

--- a/lib/commands/devinstall.js
+++ b/lib/commands/devinstall.js
@@ -17,35 +17,6 @@ module.exports = function (dependencies) {
         nodegit = require('nodegit'),
         mkdirp = require('mkdirp');
 
-
-    return {
-        devinstall: function (renderer) {
-
-            var repository = arguments.length >= 3 ? arguments[1] : Constants.FrameworkRepository,
-                localPath = path.resolve(Constants.FrameworkRepositoryName),
-                done = arguments[arguments.length-1] || function () {},
-                clone = nodegit.Clone.clone;
-
-
-            // handle repositories that already exist locally
-            var errorAndAttemptOpen = function () {
-                return nodegit.Repository.open(localPath);
-            };
-
-            // Clone a given repository into a specific folder.
-            renderer.log("Cloning adapt_framework");
-            clone(repository, localPath, null)
-                .catch(errorAndAttemptOpen)
-                .then(function(repo){
-                    repo.getCurrentBranch().then(function(branch){
-                        renderer.log("Framework cloned.");
-                        clonePlugins(localPath, renderer, done);
-                    });
-                });
-
-        }
-    };
-
     function clonePlugins(localPath, renderer) {
         renderer.log("Cloning Plugins");
 
@@ -82,4 +53,36 @@ module.exports = function (dependencies) {
             })
             .done();
     }
+
+    return {
+        devinstall: function (renderer) {
+
+            var repository = arguments.length >= 3 ? arguments[1] : Constants.FrameworkRepository,
+                localPath = path.resolve(Constants.FrameworkRepositoryName),
+                done = arguments[arguments.length-1] || function () {},
+                clone = nodegit.Clone.clone;
+
+
+            if (repository !== Constants.FrameworkRepository) {
+                return createInstallationTask(Plugin.parse(repository), localPath, renderer)
+            }
+
+            // handle repositories that already exist locally
+            var errorAndAttemptOpen = function () {
+                return nodegit.Repository.open(localPath);
+            };
+
+            // Clone a given repository into a specific folder.
+            renderer.log("Cloning adapt_framework");
+            clone(repository, localPath, null)
+                .catch(errorAndAttemptOpen)
+                .then(function(repo){
+                    repo.getCurrentBranch().then(function(branch){
+                        renderer.log("Framework cloned.");
+                        clonePlugins(localPath, renderer, done);
+                    });
+                });
+
+        }
+    };
 };

--- a/lib/commands/devinstall.js
+++ b/lib/commands/devinstall.js
@@ -62,7 +62,17 @@ module.exports = function (dependencies) {
                 done = arguments[arguments.length-1] || function () {},
                 clone = nodegit.Clone.clone;
 
+            try {
+                // Are we inside an existing adapt_framework project.
+                var packageJson = require(process.cwd() + '/package.json');
+                if (packageJson.name === 'adapt_framework') {
+                    localPath = process.cwd();
+                }
+            } catch (err) {
+                // Don't worry, we're not inside a framework directory.
+            }
 
+            // we're trying to install a single plugin.
             if (repository !== Constants.FrameworkRepository) {
                 return createInstallationTask(Plugin.parse(repository), localPath, renderer)
             }
@@ -72,7 +82,7 @@ module.exports = function (dependencies) {
                 return nodegit.Repository.open(localPath);
             };
 
-            // Clone a given repository into a specific folder.
+            // clone the framework and all the bundled plugins.
             renderer.log("Cloning adapt_framework");
             clone(repository, localPath, null)
                 .catch(errorAndAttemptOpen)

--- a/lib/commands/devinstall.js
+++ b/lib/commands/devinstall.js
@@ -1,0 +1,86 @@
+var promise = require('../promise/util');
+
+module.exports = function (dependencies) {
+
+    var chalk = dependencies.chalk || require('chalk'),
+        path = dependencies.path || require('path'),
+        Q = dependencies.Q || require('q'),
+        Constants = dependencies.Constants || require('../Constants'),
+        PluginTypeResolver = dependencies.PluginTypeResolver || require('../PluginTypeResolver'),
+        PackageMeta = dependencies.PackageMeta || require('../PackageMeta'),
+        Project = dependencies.Project || require('../Project'),
+        Plugin = dependencies.Plugin || require('../Plugin'),
+        RendererHelpers = dependencies.RendererHelpers || require('../RendererHelpers'),
+        VersionChecker = dependencies.VersionChecker || require('../VersionChecker'),
+        install = dependencies.install || require('../promise/install'),
+        cloneInstall = dependencies.cloneInstall || require('../promise/cloneInstall'),
+        nodegit = require('nodegit'),
+        mkdirp = require('mkdirp');
+
+
+    return {
+        devinstall: function (renderer) {
+
+            var repository = arguments.length >= 3 ? arguments[1] : Constants.FrameworkRepository,
+                localPath = path.resolve(Constants.FrameworkRepositoryName),
+                done = arguments[arguments.length-1] || function () {},
+                clone = nodegit.Clone.clone;
+
+
+            // handle repositories that already exist locally
+            var errorAndAttemptOpen = function () {
+                console.log("attempting to open local");
+                return nodegit.Repository.open(localPath);
+            };
+
+            // Clone a given repository into a specific folder.
+            renderer.log("Cloning adapt_framework");
+            clone(repository, localPath, null)
+                .catch(errorAndAttemptOpen)
+                .then(function(repo){
+                    repo.getCurrentBranch().then(function(branch){
+                        renderer.log("Framework cloned.");
+                        clonePlugins(localPath, renderer, done);
+                    });
+                });
+
+        }
+    };
+
+    function clonePlugins(localPath, renderer) {
+        renderer.log("Cloning Plugins");
+
+        var project = new Project(
+                path.resolve(localPath, Constants.DefaultProjectManifestPath),
+                path.resolve(localPath, Constants.DefaultProjectFrameworkPath)
+            ),
+            plugins = project.plugins;
+
+
+
+        plugins.forEach(function(plugin, index, array) {
+            createInstallationTask(plugin, localPath, renderer);
+        });
+    }
+
+
+    function createInstallationTask(plugin, localPath, renderer) {
+        return PackageMeta.getKeywords(plugin, { registry: Constants.Registry })
+            .then(function (keywords) {
+                var resolver = new PluginTypeResolver(),
+                    pluginType = resolver.resolve(keywords);
+
+                renderer.log(chalk.cyan(plugin.packageName), 'found.', 'Installing', pluginType.typename, '...');
+                return cloneInstall(plugin, {
+                    localPath: localPath,
+                    directory: path.join('src', pluginType.belongsTo),
+                    registry: Constants.Registry
+                });
+            })
+            .then(function (installed) {
+                if (!installed) throw new Error('The plugin was found but failed to download and install.');
+                renderer.log(chalk.green(plugin.packageName), 'has been installed successfully.');
+            })
+            .done();
+    }
+};

--- a/lib/commands/devinstall.js
+++ b/lib/commands/devinstall.js
@@ -29,7 +29,6 @@ module.exports = function (dependencies) {
 
             // handle repositories that already exist locally
             var errorAndAttemptOpen = function () {
-                console.log("attempting to open local");
                 return nodegit.Repository.open(localPath);
             };
 

--- a/lib/promise/cloneInstall.js
+++ b/lib/promise/cloneInstall.js
@@ -1,0 +1,30 @@
+var Q = require('q'),
+    PackageMeta = require('../PackageMeta'),
+    path = require('path'),
+    Plugin = require('../Plugin'),
+    mkdirp = require('mkdirp'),
+    nodegit = require('nodegit');
+
+module.exports = function cloneInstall(plugin, options) {
+    var deferred = Q.defer();
+
+    PackageMeta.getRepositoryUrl(plugin)
+        .then(function(repoDetails) {
+            mkdirp(path.resolve(options.localPath, options.directory), function (err) {
+                if (err) {
+                    return deferred.reject(err);
+                }
+                var pluginPath = path.resolve(options.localPath, options.directory, plugin.name);
+
+                nodegit.Clone.clone(repoDetails.url, pluginPath, null);
+            });
+        })
+        .then(function(repo){
+            deferred.resolve(plugin)
+        })
+        .fail(function(err) {
+            deferred.reject(err);
+        })
+        .done();
+    return deferred.promise;
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "download": "git://github.com/adaptlearning/download.git",
     "grunt": "~0.4.5",
     "lodash": "~3.6.0",
+    "mkdirp": "^0.5.1",
+    "nodegit": "^0.6.3",
     "npm": "~2.7.4",
     "prompt": "~0.2.14",
     "q": "^1.2.1",


### PR DESCRIPTION
This is a bit speculative.

I wanted a way to get the framework and all the bundled plugins checked out as git repos so I could do a bit of development. The `adapt install [x]` and `adapt create course` commands didn't give a git repo that I could add my fork as a remote to.

This devinstall command will clone the adapt_framework and all the plugins defined in adapt.json as git repos allowing you to get going faster.

Run it as `adapt devinstall` to create an adapt_framework repo in your current directory.
It should run ok from within a previously created adapt_framework directory.

You can install a single plugin via `adapt devinstall [pluginname]` from within `_root/adapt_framework` or `_root/`