### PR TITLE
Fixes issue #53

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bower-endpoint-parser": "~0.2.2",
     "chalk": "~1.0.0",
     "debug": "~2.1.3",
-    "download": "git://github.com/adaptlearning/download.git",
+    "download": "0.1.18",
     "grunt": "~0.4.5",
     "lodash": "~3.6.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
We are trying to assess adapt as a candidate for adoption as _the_ learning delivery platform in our (large) organisation.

This is a blocker. We've already lost a couple of months on it.

The PR simply points your package.json from your fork of `download` on github to the exact same version packaged and published in NPM.

Closes #53 