### PR TITLE
Target registry consistently (envvar>.bowerrc>constant)

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,3 +1,6 @@
+var bower = require('bower'),
+    fs = require('fs');
+
 module.exports = {
     DefaultProjectManifestPath : './adapt.json',
     DefaultProjectFrameworkPath: './package.json',
@@ -11,13 +14,12 @@ module.exports = {
     ComponentRepository : process.env.ADAPT_COMPONENT || 'https://github.com/adaptlearning/adapt-component',
     ComponentRepositoryName : 'adapt-component',
     DefaultBranch : process.env.ADAPT_BRANCH || 'master',
-    Registry: process.env.ADAPT_REGISTRY || 'http://adapt-bower-repository.herokuapp.com/',
+    Registry: getRegistry(),
     HomeDirectory : searchForHome()
 };
 
 function searchForHome() {
-    var fs = require('fs'),
-        locations = [
+    var locations = [
             process.env.HOME,
             (process.env.HOMEDRIVE + process.env.HOMEPATH),
             process.env.USERPROFILE,
@@ -26,4 +28,10 @@ function searchForHome() {
         ];
     var validLocations =  locations.filter(fs.existsSync);
     return validLocations[0];
+}
+
+function getRegistry() {
+    if (process.env.ADAPT_REGISTRY) return process.env.ADAPT_REGISTRY;
+    if (fs.existsSync('./.bowerrc')) return bower.config.registry.publish;
+    return 'http://adapt-bower-repository.herokuapp.com/';
 }

--- a/lib/commands/register.js
+++ b/lib/commands/register.js
@@ -14,7 +14,7 @@ module.exports = {
     register: function (renderer) {
         var done = arguments[arguments.length-1] || function () {};
 
-        renderer.log(chalk.yellow('This will publish this plugin to', bower.config.registry.publish));
+        renderer.log(chalk.yellow('This will publish this plugin to', Constants.Registry));
 
         loadPluginProperties('./bower.json', {
             name: undefined,
@@ -149,7 +149,7 @@ function confirm(properties) {
 function register(plugin, repository) {
     var deferred = Q.defer();
 
-    bower.commands.register(plugin.toString(), repository)
+    bower.commands.register(plugin.toString(), repository, { registry: Constants.Registry })
     .on('end', function(result) {
         deferred.resolve({ result: result, plugin: plugin });
     })

--- a/lib/commands/unregister.js
+++ b/lib/commands/unregister.js
@@ -20,7 +20,7 @@ module.exports = {
             pluginName = arguments[1];
         }
 
-        log(chalk.yellow('This will unregister the plugin at', bower.config.registry.publish));
+        log(chalk.yellow('This will unregister the plugin at', Constants.Registry));
         
          getProperties(pluginName)
         .then(authenticate)
@@ -91,8 +91,8 @@ function confirm(properties) {
 function unregister(properties) {
     var deferred = Q.defer();
     
-    // user (username) with OAuth (token) wants to unregister the registered plugin (name)
-    bower.commands.unregister(properties.username+'/'+properties.name, {token:properties.token})
+    // user (username) with OAuth (token) wants to unregister the registered plugin (name) from registry
+    bower.commands.unregister(properties.username+'/'+properties.name, {token:properties.token, registry: Constants.Registry})
     .on('end', function (result) {
         //log('end', result);
         deferred.resolve();


### PR DESCRIPTION
To avoid the situation where a missing `.bowerrc` results in bower using its default registry (`bower.herokuapp.com`) the code has been amended so that the CLI determines the registry by first checking for the `ADAPT_REGISTRY` environment variable, then attempting to read the property`registry` from `.bowerrc`, before falling back to a constant `adapt-bower-repository.herokuapp.com`.