### PR TITLE
Fix for #76

### DIFF
--- a/lib/VersionChecker.js
+++ b/lib/VersionChecker.js
@@ -2,10 +2,6 @@ var semver = require('semver');
 
 module.exports = {
     assertVersionCompatibility: function (adaptVersion, compatibleVersionRange) {
-        var any = /\*|>=0.0.0/;
-        if(semver.gte(adaptVersion, '2.0.0') && any.test(compatibleVersionRange)) {
-            return false;
-        }
         return semver.satisfies(adaptVersion, compatibleVersionRange);
     }
 };

--- a/test/specs/installing_incompatible_plugins_concerns.js
+++ b/test/specs/installing_incompatible_plugins_concerns.js
@@ -30,32 +30,6 @@ describe('Given that I have Adapt Framework version 2', function () {
             RendererHelpers.reportCompatibilityWarning.restore();
         });
     });
-
-    describe('When I install a plugin that is not tagged with a framework version', function () {
-        it('should warn that the plugin is incompatible', function (done) {
-
-            var context = createContext({
-                frameworkVersion: '2.0.0',
-                pluginCompatibility: '*'
-            });
-
-            var installCommand = require('../../lib/commands/install')(context);
-
-            installCommand.install(context.renderer, 'plugin', function (err) {
-                console.log(RendererHelpers.reportCompatibilityWarning.called)
-                try {
-                    expect(RendererHelpers.reportCompatibilityWarning.called).to.be(true);
-                    done();
-                }
-                catch(ex) { done(ex) }
-            });
-        });
-
-        after(function() {
-            Project.prototype.getFrameworkVersion.restore();
-            RendererHelpers.reportCompatibilityWarning.restore();
-        });
-    });
 });
 
 describe('Given that I have Adapt Framework version 1.1.1 or earlier', function () {


### PR DESCRIPTION
Resolves repeated erroneous warnings about plugin compatibility with Adapt when using commands such as:

`adapt create course` and `adapt install`