### PR TITLE
issue/#83 : fixed getRepositoryUrl for devinstall

### DIFF
--- a/lib/PackageMeta.js
+++ b/lib/PackageMeta.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     getRepositoryUrl: function (plugin, config) {
         var deferred = Q.defer();
-        bower.commands.lookup(plugin.toString(), config || {})
+        bower.commands.lookup(plugin.name, config || {})
             .on('end', function(results) {
                 deferred.resolve(results);
             })


### PR DESCRIPTION
`getRepositoryUrl` was attempting to search bower using `name#>=version` when it should just be `name`.

Resolves #83.