### PR TITLE
Expose commands as an API

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -58,13 +58,8 @@ function getRegistry() {
 function setCwd(cwd) {
     if (!cwd) return;
 
-    console.log('setting cwd to', cwd);
-
     this.cwd = cwd;
 
     this.DefaultProjectManifestPath = path.join(this.cwd, this.DefaultProjectManifestPath);
     this.DefaultProjectFrameworkPath = path.join(this.cwd, this.DefaultProjectFrameworkPath);
-
-    console.log(this.DefaultProjectManifestPath);
-    console.log(this.DefaultProjectFrameworkPath);
 }

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,5 +1,6 @@
 var bower = require('bower'),
-    fs = require('fs');
+    fs = require('fs'),
+    path = require('path');
 
 module.exports = {
     DefaultProjectManifestPath : './adapt.json',
@@ -15,7 +16,9 @@ module.exports = {
     ComponentRepositoryName : 'adapt-component',
     DefaultBranch : process.env.ADAPT_BRANCH || 'master',
     HomeDirectory : searchForHome(),
-    getRegistry:getRegistry
+    getRegistry:getRegistry,
+    setCwd: setCwd,
+    cwd: '.'
 };
 
 var registry = null;
@@ -40,7 +43,7 @@ function getRegistry() {
     if (process.env.ADAPT_REGISTRY) {
         registry = process.env.ADAPT_REGISTRY;
 
-    } else if (fs.existsSync('./.bowerrc')) {
+    } else if (fs.existsSync(path.join(this.cwd, './.bowerrc'))) {
         // a manifest exists; let bower determine the registry
         registry = undefined;
         
@@ -50,4 +53,18 @@ function getRegistry() {
     }
 
     return registry;
+}
+
+function setCwd(cwd) {
+    if (!cwd) return;
+
+    console.log('setting cwd to', cwd);
+
+    this.cwd = cwd;
+
+    this.DefaultProjectManifestPath = path.join(this.cwd, this.DefaultProjectManifestPath);
+    this.DefaultProjectFrameworkPath = path.join(this.cwd, this.DefaultProjectFrameworkPath);
+
+    console.log(this.DefaultProjectManifestPath);
+    console.log(this.DefaultProjectFrameworkPath);
 }

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -3,8 +3,10 @@ var bower = require('bower'),
     path = require('path');
 
 module.exports = {
-    DefaultProjectManifestPath : './adapt.json',
-    DefaultProjectFrameworkPath: './package.json',
+    ManifestFilename: 'adapt.json',
+    FrameworkFilename: 'package.json',
+    DefaultProjectManifestPath : './'+this.ManifestFilename,
+    DefaultProjectFrameworkPath: './'+this.FrameworkFilename,
     DefaultCreateType : 'course',
     DefaultTypeNames : {
         'course':'my-adapt-course',
@@ -60,6 +62,6 @@ function setCwd(cwd) {
 
     this.cwd = cwd;
 
-    this.DefaultProjectManifestPath = path.join(this.cwd, this.DefaultProjectManifestPath);
-    this.DefaultProjectFrameworkPath = path.join(this.cwd, this.DefaultProjectFrameworkPath);
+    this.DefaultProjectManifestPath = path.join(this.cwd, this.ManifestFilename);
+    this.DefaultProjectFrameworkPath = path.join(this.cwd, this.FrameworkFilename);
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -27,9 +27,26 @@ function execute() {
     });
 }
 
+function getApi() {
+    var commands = require('./commands');
+    var apiCommands = {};
+
+    _.each(commands, function(command, commandName) {
+        var prefix = 'api';
+        if (commandName.startsWith(prefix)) {
+            apiCommands[commandName.split(prefix)[1]] = command;
+        }
+    });
+
+    return {
+        commands:apiCommands
+    }
+}
+
 module.exports = {
     command: null,
     withOptions: withOptions,
     withPackage: withPackage,
-    execute: execute
+    execute: execute,
+    api: getApi()
 };

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -12,7 +12,6 @@ var semver = require('semver');
 var Errors = require('../errors');
 var Constants = require('../Constants');
 var JsonLoader = require('../JsonLoader');
-var JsonWriter = require('../JsonWriter');
 var PackageMeta = require('../PackageMeta');
 var Plugin = require('../Plugin');
 var Project = require('../Project');
@@ -46,7 +45,7 @@ module.exports = function (dependencies) {
         apiinstall: function(pluginName, cwd) {
             isInteractive = false;
 
-            if (cwd) process.chdir(cwd);
+            Constants.setCwd(cwd);
 
             project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
 
@@ -57,7 +56,7 @@ module.exports = function (dependencies) {
             itinerary = {};
             plugins = [];
 
-            return init([pluginName])
+            return init(pluginName ? [pluginName] : [])
             .then(createPlugins)
             .then(getInitialInfo)
             .then(findCompatibleVersions)
@@ -273,33 +272,28 @@ module.exports = function (dependencies) {
         var compatibleWithUnmetConstraint = present.filter(isCompatibleWithUnmetConstraint);
 
         if (!isInteractive) {
-            var errors = [];
 
-            if (incompatibleWithOldConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_INCOMPATIBLE_VALID_REQUEST, context:incompatibleWithOldConstraint.map(getPackageName)});
-            }
-            if (incompatibleWithLatestConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_INCOMPATIBLE_VALID_REQUEST, context:incompatibleWithLatestConstraint.map(getPackageName)});
-            }
-            if (incompatibleWithBadConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_INCOMPATIBLE_BAD_REQUEST, context:incompatibleWithBadConstraint.map(getPackageName)});
-            }
-            if (incompatibleWithNoConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_INCOMPATIBLE, context:incompatibleWithNoConstraint.map(getPackageName)});
-            }
-            if (compatibleWithOldIncompatibleConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_COMPATIBLE_INC_REQUEST, context:compatibleWithOldIncompatibleConstraint.map(getPackageName)});
-            }
-            if (compatibleWithBadConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_COMPATIBLE_BAD_REQUEST, context:compatibleWithBadConstraint.map(getPackageName)});
-            }
-            if (compatibleWithUnmetConstraint.length > 0) {
-                errors.push({error:Errors.ERROR_COMPATIBLE_INC_REQUEST, context:compatibleWithUnmetConstraint.map(getPackageName)});
-            }
-
-            if (errors.length > 0) {
-                return Q.reject(errors);
-            }
+            incompatibleWithOldConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_INCOMPATIBLE_VALID_REQUEST;
+            });
+            incompatibleWithLatestConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_INCOMPATIBLE_VALID_REQUEST;
+            });
+            incompatibleWithBadConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_INCOMPATIBLE_BAD_REQUEST;
+            });
+            incompatibleWithNoConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_INCOMPATIBLE;
+            });
+            compatibleWithOldIncompatibleConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_COMPATIBLE_INC_REQUEST;
+            });
+            compatibleWithBadConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_COMPATIBLE_BAD_REQUEST;
+            });
+            compatibleWithUnmetConstraint.forEach(function(p) {
+                p._error = Errors.ERROR_COMPATIBLE_INC_REQUEST;
+            });
 
             compatibleWithOldCompatibleConstraint.forEach(function(p) {
                 p.markRequestedForInstallation();
@@ -556,25 +550,63 @@ module.exports = function (dependencies) {
         var successMsg;
 
         if (!isInteractive) {
-            var report = {
-                success:{},
-                errored:{},
-                missing:[]
+            var report = [];
+
+            if (plugins.length == 1) {
+                var p = plugins[0];
+
+                if (installSucceeded.length == 1) {
+                    var bowerPath = path.join(Constants.cwd, 'src', p._belongsTo, p.packageName, 'bower.json');
+                    return Q.resolve(JsonLoader.readJSONSync(bowerPath));
+                }
+                if (installSkipped.length == 1) {
+                    return Q.reject(p._error);
+                }
+                if (installErrored.length == 1) {
+                    var error = _.clone(Errors.ERROR_INSTALL_ERROR);
+
+                    if (p._installError) error.msg = p._installError;
+
+                    return Q.reject(error);
+                }
+                return Q.reject(Errors.ERROR_NOT_FOUND);
             }
             
             installSucceeded.forEach(function(p) {
-                var bowerPath = path.join('src', p._belongsTo, p.packageName, 'bower.json');
-                report.success[p.packageName] = JsonLoader.readJSONSync(bowerPath);
+                var bowerPath = path.join(Constants.cwd, 'src', p._belongsTo, p.packageName, 'bower.json');
+                report.push({
+                    name:p.packageName,
+                    status:'fulfilled',
+                    pluginData:JsonLoader.readJSONSync(bowerPath)
+                });
+            });
+
+            installSkipped.forEach(function(p) {
+                report.push({
+                    name:p.packageName,
+                    status:'rejected',
+                    reason:p._error
+                });
             });
 
             installErrored.forEach(function(p) {
-                report.errored[p.packageName] = {
-                    errorMessage: p._installError ? p._installError : 'unknown error'
-                };
+                var error = _.clone(Errors.ERROR_INSTALL_ERROR);
+
+                if (p._installError) error.msg = p._installError;
+
+                report.push({
+                    name:p.packageName,
+                    status:'rejected',
+                    reason:error
+                });
             });
 
             missing.forEach(function(p) {
-                report.missing.push(p.packageName);
+                report.push({
+                    name:p.packageName,
+                    status:'rejected',
+                    reason:Errors.ERROR_NOT_FOUND
+                });
             });
 
             return Q.resolve(report);
@@ -809,7 +841,7 @@ module.exports = function (dependencies) {
             plugin._belongsTo = pluginType.belongsTo;
 
             return install(plugin, {
-                directory: path.join('src', pluginType.belongsTo),
+                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo),
                 registry: Constants.getRegistry()
             });
         }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -831,7 +831,7 @@ module.exports = function (dependencies) {
     }
 
     function createInstallationTask(plugin) {
-        return PackageMeta.getKeywords(plugin, { registry: Constants.getRegistry() }).then(doInstall).then(conclude);
+        return PackageMeta.getKeywords(plugin, { registry: Constants.getRegistry(), cwd: Constants.cwd }).then(doInstall).then(conclude);
 
         function doInstall(keywords) {
             var resolver = new PluginTypeResolver(),
@@ -841,8 +841,9 @@ module.exports = function (dependencies) {
             plugin._belongsTo = pluginType.belongsTo;
 
             return install(plugin, {
-                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo),
-                registry: Constants.getRegistry()
+                directory: path.join('src', pluginType.belongsTo),
+                registry: Constants.getRegistry(),
+                cwd: Constants.cwd
             });
         }
         

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -565,7 +565,7 @@ module.exports = function (dependencies) {
                 if (installErrored.length == 1) {
                     var error = _.clone(Errors.ERROR_INSTALL_ERROR);
 
-                    if (p._installError) error.msg = p._installError;
+                    if (p._installError) error.message = p._installError;
 
                     return Q.reject(error);
                 }
@@ -592,7 +592,7 @@ module.exports = function (dependencies) {
             installErrored.forEach(function(p) {
                 var error = _.clone(Errors.ERROR_INSTALL_ERROR);
 
-                if (p._installError) error.msg = p._installError;
+                if (p._installError) error.message = p._installError;
 
                 report.push({
                     name:p.packageName,

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -9,6 +9,7 @@ var path = require('path');
 var prompt = require('prompt')
 var Q = require('q');
 var semver = require('semver');
+var Errors = require('../errors');
 var Constants = require('../Constants');
 var JsonLoader = require('../JsonLoader');
 var JsonWriter = require('../JsonWriter');
@@ -38,8 +39,31 @@ module.exports = function (dependencies) {
     var isCompatibleEnabled = false;
     // whether adapt.json is being used to compile the list of plugins to install
     var isUsingManifest = false;
+    // whether this command is being performed on the command line
+    var isInteractive = true;
 
     return {
+        apiinstall: function(pluginName) {
+            isInteractive = false;
+
+            project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
+
+            if(!project.isProjectContainsManifestFile()) {
+                return Q.reject({error:Errors.ERROR_COURSE_DIR});
+            }
+
+            itinerary = {};
+            plugins = [];
+
+            return init([pluginName])
+            .then(createPlugins)
+            .then(getInitialInfo)
+            .then(findCompatibleVersions)
+            .then(checkConstraints)
+            .then(createInstallationManifest)
+            .then(performInstallation)
+            .then(summariseInstallation);
+        },
         install: function(renderer) {
             var args = [].slice.call(arguments, 1);
             var done = args.pop() || function() {};
@@ -145,7 +169,11 @@ module.exports = function (dependencies) {
             promises.push(plugins[i].getInitialInfo());
         }
 
-        return Q.all(promises).progress(progressUpdate).then(conclude);
+        if (isInteractive) {
+            return Q.all(promises).progress(progressUpdate).then(conclude);
+        }
+
+        return Q.all(promises);
 
         function progressUpdate() {
             var settled = plugins.filter(function(plugin) {return plugin._rawInfo || plugin._isMissingAtRepo;}).length;
@@ -169,7 +197,11 @@ module.exports = function (dependencies) {
             promises.push(present[i].findCompatibleVersion(project.getFrameworkVersion()));
         }
         
-        return Q.all(promises).progress(progressUpdate).then(conclude);
+        if (isInteractive) {
+            return Q.all(promises).progress(progressUpdate).then(conclude);
+        }
+
+        return Q.all(promises);
 
         function progressUpdate() {
             var settled = present.filter(function(plugin) {return plugin._latestCompatibleVersion != undefined;}).length;
@@ -193,7 +225,11 @@ module.exports = function (dependencies) {
             promises.push(present[i].checkConstraint(project.getFrameworkVersion()));
         }
         
-        return Q.all(promises).progress(progressUpdate).then(conclude);
+        if (isInteractive) {
+            return Q.all(promises).progress(progressUpdate).then(conclude);
+        }
+
+        return Q.all(promises);
 
         function progressUpdate() {
             var settled = present.filter(function(plugin) {return plugin._constraintChecked != undefined;}).length;
@@ -234,6 +270,38 @@ module.exports = function (dependencies) {
         // a compatible version exists but user has requested a valid version that is later than the latest compatible version (prompt for (r)equested, (l)atest compatible or (s)kip)
         var compatibleWithUnmetConstraint = present.filter(isCompatibleWithUnmetConstraint);
 
+        if (!isInteractive) {
+            var errors = [];
+
+            if (incompatibleWithOldConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_INCOMPATIBLE_VALID_REQUEST, context:incompatibleWithOldConstraint.map(getPackageName)});
+            }
+            if (incompatibleWithLatestConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_INCOMPATIBLE_VALID_REQUEST, context:incompatibleWithLatestConstraint.map(getPackageName)});
+            }
+            if (incompatibleWithBadConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_INCOMPATIBLE_BAD_REQUEST, context:incompatibleWithBadConstraint.map(getPackageName)});
+            }
+            if (incompatibleWithNoConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_INCOMPATIBLE, context:incompatibleWithNoConstraint.map(getPackageName)});
+            }
+            if (compatibleWithOldIncompatibleConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_COMPATIBLE_INC_REQUEST, context:compatibleWithOldIncompatibleConstraint.map(getPackageName)});
+            }
+            if (compatibleWithBadConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_COMPATIBLE_BAD_REQUEST, context:compatibleWithBadConstraint.map(getPackageName)});
+            }
+            if (compatibleWithUnmetConstraint.length > 0) {
+                errors.push({error:Errors.ERROR_COMPATIBLE_INC_REQUEST, context:compatibleWithUnmetConstraint.map(getPackageName)});
+            }
+
+            if (errors.length > 0) {
+                return Q.reject(errors);
+            }
+
+            return Q.resolve();
+        }
+
         var allPromises = [];
 
         add(incompatibleWithOldConstraint, 'There is no compatible version of the following plugins:', getPrompt_incompatibleGeneric);
@@ -269,6 +337,10 @@ module.exports = function (dependencies) {
         function execute(obj) {
             console.log(obj.header);
             return promise.serialise(obj.list, obj.prompt);
+        }
+
+        function getPackageName(p) {
+            return p.packageName;
         }
     }
 
@@ -477,6 +549,33 @@ module.exports = function (dependencies) {
         var noSuccess = 'None of the requested plugins could be installed';
         var successMsg;
 
+        if (!isInteractive) {
+            var report = {
+                success:{},
+                errored:{},
+                missing:[]
+            }
+            
+            installSucceeded.forEach(function(p) {
+                report.success[p.packageName] = {
+                    installedVersion: p._versionToInstall,
+                    latestCompatibleVersion: p._latestCompatibleVersion
+                };
+            });
+
+            installErrored.forEach(function(p) {
+                report.errored[p.packageName] = {
+                    errorMessage: p._installError ? p._installError : 'unknown error'
+                };
+            });
+
+            missing.forEach(function(p) {
+                report.missing.push(p.packageName);
+            });
+
+            return Q.resolve(report);
+        }
+
         if (installErrored.length == 0 && missing.length == 0) successMsg = allSuccess;
         else if (installSucceeded.length == 0) successMsg = noSuccess;
         else successMsg = someSuccess;
@@ -676,7 +775,11 @@ module.exports = function (dependencies) {
     }
 
     function performInstallation() {
-        return Q.all(plugins.filter(isToBeInstalled).map(createInstallationTask)).progress(progressUpdate).then(conclude);
+        if (isInteractive) {
+            return Q.all(plugins.filter(isToBeInstalled).map(createInstallationTask)).progress(progressUpdate).then(conclude);
+        }
+
+        return Q.all(plugins.filter(isToBeInstalled).map(createInstallationTask));
 
         function progressUpdate() {
             var list = plugins.filter(isPresent).filter(isToBeInstalled);

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -43,8 +43,10 @@ module.exports = function (dependencies) {
     var isInteractive = true;
 
     return {
-        apiinstall: function(pluginName) {
+        apiinstall: function(pluginName, cwd) {
             isInteractive = false;
+
+            if (cwd) process.chdir(cwd);
 
             project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
 
@@ -298,6 +300,10 @@ module.exports = function (dependencies) {
             if (errors.length > 0) {
                 return Q.reject(errors);
             }
+
+            compatibleWithOldCompatibleConstraint.forEach(function(p) {
+                p.markRequestedForInstallation();
+            });
 
             return Q.resolve();
         }
@@ -557,10 +563,8 @@ module.exports = function (dependencies) {
             }
             
             installSucceeded.forEach(function(p) {
-                report.success[p.packageName] = {
-                    installedVersion: p._versionToInstall,
-                    latestCompatibleVersion: p._latestCompatibleVersion
-                };
+                var bowerPath = path.join('src', p._belongsTo, p.packageName, 'bower.json');
+                report.success[p.packageName] = JsonLoader.readJSONSync(bowerPath);
             });
 
             installErrored.forEach(function(p) {

--- a/lib/commands/install/InstallTarget.js
+++ b/lib/commands/install/InstallTarget.js
@@ -87,7 +87,7 @@ var InstallTarget = extend(Plugin, {
         try {
             var versionString = this._versions ? '#'+this._versions[this._versionIndex] : '';
             this._bowerCmdCount++;
-            bower.commands.info(this.packageName+versionString, null, {registry:Constants.getRegistry()}).on('end', _.bind(onSuccess, this)).on('error', _.bind(onFail, this));
+            bower.commands.info(this.packageName+versionString, null, {registry:Constants.getRegistry(), cwd: Constants.cwd}).on('end', _.bind(onSuccess, this)).on('error', _.bind(onFail, this));
         } catch(err) {
             onFail.call(this, err);
         }

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -13,7 +13,9 @@ var chalk = require('chalk'),
     Errors = require('../errors');
 
 module.exports = {
-    apiuninstall:function(pluginName) {
+    apiuninstall:function(pluginName, cwd) {
+        if (cwd) process.chdir(cwd);
+
         var project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
 
         if(!project.isProjectContainsManifestFile()) {

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -14,7 +14,7 @@ var chalk = require('chalk'),
 
 module.exports = {
     apiuninstall:function(pluginName, cwd) {
-        if (cwd) process.chdir(cwd);
+        Constants.setCwd(cwd);
 
         var project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
 
@@ -31,7 +31,7 @@ module.exports = {
                 pluginType = resolver.resolve(keywords);
 
             return uninstallPackage(plugin, {
-                directory: path.join('src', pluginType.belongsTo)
+                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo)
             });
         })
         .then(function () {
@@ -47,7 +47,7 @@ module.exports = {
             var removePath;
             
             ['components', 'extensions', 'menu', 'theme'].forEach(function(pluginType) {
-                var pluginPath = path.join('src', pluginType, plugin.packageName);
+                var pluginPath = path.join(Constants.cwd, 'src', pluginType, plugin.packageName);
                 
                 if (fs.existsSync(pluginPath)) {
                     removePath = pluginPath;
@@ -93,7 +93,7 @@ module.exports = {
 
             renderer.log(chalk.cyan(plugin.packageName), 'found.', 'Uninstalling', pluginType.typename, '...');
             return uninstallPackage(plugin, {
-                directory: path.join('src', pluginType.belongsTo)
+                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo)
             });
         })
         .then(function () {
@@ -109,7 +109,7 @@ module.exports = {
             var removePath;
             
             ['components', 'extensions', 'menu', 'theme'].forEach(function(pluginType) {
-                var pluginPath = path.join('src', pluginType, plugin.packageName);
+                var pluginPath = path.join(Constants.cwd, 'src', pluginType, plugin.packageName);
                 
                 if (fs.existsSync(pluginPath)) {
                     removePath = pluginPath;

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -31,7 +31,8 @@ module.exports = {
                 pluginType = resolver.resolve(keywords);
 
             return uninstallPackage(plugin, {
-                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo)
+                directory: path.join('src', pluginType.belongsTo),
+                cwd:Constants.cwd
             });
         })
         .then(function () {
@@ -93,7 +94,8 @@ module.exports = {
 
             renderer.log(chalk.cyan(plugin.packageName), 'found.', 'Uninstalling', pluginType.typename, '...');
             return uninstallPackage(plugin, {
-                directory: path.join(Constants.cwd, 'src', pluginType.belongsTo)
+                directory: path.join('src', pluginType.belongsTo),
+                cwd:Constants.cwd
             });
         })
         .then(function () {

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -1,14 +1,73 @@
 var chalk = require('chalk'),
+    fs = require('fs'),
     path = require('path'),
+    rimraf = require('rimraf'),
+    Q = require('q'),
     Constants = require('../Constants'),
     PluginTypeResolver =  require('../PluginTypeResolver'),
     PackageMeta = require('../PackageMeta'),
     Project =  require('../Project'),
     Plugin = require('../Plugin'),
     RendererHelpers = require('../RendererHelpers'),
-    uninstallPackage = require('../promise/uninstallPackage');
+    uninstallPackage = require('../promise/uninstallPackage'),
+    Errors = require('../errors');
 
 module.exports = {
+    apiuninstall:function(pluginName) {
+        var project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
+
+        if(!project.isProjectContainsManifestFile()) {
+            return Q.reject({error:Errors.ERROR_COURSE_DIR});
+        }
+
+        var plugin = Plugin.parse(pluginName);
+        var deferred = Q.defer();
+
+        PackageMeta.getKeywords(plugin, { registry: Constants.getRegistry() })
+        .then(function (keywords) {
+            var resolver = new PluginTypeResolver(),
+                pluginType = resolver.resolve(keywords);
+
+            return uninstallPackage(plugin, {
+                directory: path.join('src', pluginType.belongsTo)
+            });
+        })
+        .then(function () {
+            project.remove(plugin);
+        })
+        .then(function () {
+            deferred.resolve(pluginName);
+        })
+        .fail(function() {
+            // will fail if plugin has not been installed by Bower (i.e. the .bower.json manifest is missing)
+            // so just try and remove the directory (this is basically what Bower does anyway)
+
+            var removePath;
+            
+            ['components', 'extensions', 'menu', 'theme'].forEach(function(pluginType) {
+                var pluginPath = path.join('src', pluginType, plugin.packageName);
+                
+                if (fs.existsSync(pluginPath)) {
+                    removePath = pluginPath;
+                }
+            });
+
+            if (removePath) {
+                rimraf(removePath, function() {
+                    if (fs.existsSync(removePath)) {
+                        deferred.reject({error:Errors.ERROR_UNINSTALL});
+                    } else {
+                        project.remove(plugin);
+                        deferred.resolve(pluginName);
+                    }
+                });
+            } else {
+                deferred.reject({error:Errors.ERROR_NOT_FOUND});
+            }
+        });
+
+        return deferred.promise;
+    },
     uninstall: function (renderer) {
 
         var packageName = arguments.length >= 3 ? arguments[1] : null,
@@ -35,15 +94,39 @@ module.exports = {
                 directory: path.join('src', pluginType.belongsTo)
             });
         })
-        .then(function (uninstalled) {
-            if(uninstalled) {
-                project.remove(plugin);
-            }
+        .then(function () {
+            project.remove(plugin);
         })
         .then(function () {
             done();
         })
-        .fail(RendererHelpers.reportFailure(renderer, done));
+        .fail(function() {
+            // will fail if plugin has not been installed by Bower (i.e. the .bower.json manifest is missing)
+            // so just try and remove the directory (this is basically what Bower does anyway)
+
+            var removePath;
+            
+            ['components', 'extensions', 'menu', 'theme'].forEach(function(pluginType) {
+                var pluginPath = path.join('src', pluginType, plugin.packageName);
+                
+                if (fs.existsSync(pluginPath)) {
+                    removePath = pluginPath;
+                }
+            });
+
+            if (removePath) {
+                rimraf(removePath, function() {
+                    if (fs.existsSync(removePath)) {
+                        RendererHelpers.reportFailure(renderer, done);
+                    } else {
+                        project.remove(plugin);
+                        done();
+                    }
+                });
+            } else {
+                RendererHelpers.reportFailure(renderer, done);
+            }
+        });
     }
 
 };

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -19,7 +19,7 @@ module.exports = {
         var project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
 
         if(!project.isProjectContainsManifestFile()) {
-            return Q.reject({error:Errors.ERROR_COURSE_DIR});
+            return Q.reject(Errors.ERROR_COURSE_DIR);
         }
 
         var plugin = Plugin.parse(pluginName);
@@ -58,14 +58,14 @@ module.exports = {
             if (removePath) {
                 rimraf(removePath, function() {
                     if (fs.existsSync(removePath)) {
-                        deferred.reject({error:Errors.ERROR_UNINSTALL});
+                        deferred.reject(Errors.ERROR_UNINSTALL);
                     } else {
                         project.remove(plugin);
                         deferred.resolve(pluginName);
                     }
                 });
             } else {
-                deferred.reject({error:Errors.ERROR_NOT_FOUND});
+                deferred.reject(Errors.ERROR_NOT_FOUND);
             }
         });
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -50,8 +50,10 @@ module.exports = function() {
     var isInteractive = true;
 
     return {
-        apiupdate: function(pluginName) {
+        apiupdate: function(pluginName, cwd) {
             isInteractive = false;
+
+            if (cwd) process.chdir(cwd);
 
             clean();
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -17,6 +17,7 @@ var RendererHelpers = require('../RendererHelpers');
 var VersionChecker = require('../VersionChecker')
 var update = require('../promise/update');
 var promise = require('../promise/util');
+var Errors = require('../errors');
 var readline = require('readline');
 
 module.exports = function() {
@@ -44,8 +45,40 @@ module.exports = function() {
     var isDebuggingEnabled = false;
     // when a bower command errors this is the maximum number of attempts the command will be repeated
     var bowerCmdMaxTry = 5;
+    var installedPlugins;
+    // whether this command is being performed on the command line
+    var isInteractive = true;
 
     return {
+        apiupdate: function(pluginName) {
+            isInteractive = false;
+
+            clean();
+
+            bowerJson = {"name": "manifest", "dependencies":{}};
+            project = new Project(Constants.DefaultProjectManifestPath, Constants.DefaultProjectFrameworkPath);
+            plugins = [];
+            installedPlugins = {};
+
+            if (!project.isProjectContainsManifestFile()) {
+                return Q.reject({error:Errors.ERROR_COURSE_DIR});
+            }
+
+            args = pluginName ? [pluginName] : ['all'];
+
+            discoverPlugins();
+
+            return Q(args)
+                .then(createManifestFromArguments)
+                .then(checkRedundancy)
+                .then(createPlugins)
+                .then(determineTargetVersions)
+                .then(checkIncompatible)
+                .then(performUpdates)
+                .then(verifyChanged)
+                .then(printUpdateSummary)
+                .finally(clean);
+        },
         update: function(renderer) {
             var args = [].slice.call(arguments, 1);
             var done = args.pop() || function() {};
@@ -213,7 +246,10 @@ module.exports = function() {
 
     function checkRedundancy() {
         if (Object.keys(bowerJson.dependencies).length == 0) {
-            return Q.reject({message:'No valid targets specified (please check spelling and case).'});
+            if (isInteractive) {
+                return Q.reject({message:'No valid targets specified (please check spelling and case).'});
+            }
+            return Q.reject({error:Errors.ERROR_NOTHING_TO_UPDATE});
         } else {
             return Q.resolve();
         }
@@ -235,6 +271,10 @@ module.exports = function() {
 
         for (var i=0, c=plugins.length; i<c; i++) {
             promiseToGetInfo.push(getInfo(plugins[i]));
+        }
+
+        if (!isInteractive) {
+            return Q.all(promiseToGetInfo);
         }
 
         return Q.all(promiseToGetInfo).progress(function() {
@@ -422,6 +462,18 @@ module.exports = function() {
         return maxSatisfying != null && !semver.satisfies(maxSatisfying, plugin._installedVersion);
     }
 
+    function checkIncompatible() {
+        var list = plugins.filter(isPresent).filter(isIncompatible).filter(isConstrained).filter(someOtherVersionSatisfiesConstraint);
+
+        if (list.length == 0) return Q.resolve();
+
+        var names = list.map(function(p) {
+            return p.packageName;
+        });
+
+        return Q.reject({error:Errors.ERROR_UPDATE_INCOMPATIBLE, context:names});
+    }
+
     function promptToUpdateIncompatible() {
         //console.log('promptToUpdateIncompatible');
         var adaptVersion = project.getFrameworkVersion();
@@ -458,7 +510,7 @@ module.exports = function() {
             return createUpdateTask(plugin);
         })
         .then(function() {
-            renderUpdateProgressFinished();
+            if (isInteractive) renderUpdateProgressFinished();
         });
     }
 
@@ -467,9 +519,9 @@ module.exports = function() {
             if (!plugin._wasUpdated) return;
 
             var p = path.join('src', plugin._belongsTo, plugin.packageName, 'bower.json');
-            var j = JsonLoader.readJSONSync(p);
 
-            plugin._updatedVersion = j.version;
+            plugin._bowerInfo = JsonLoader.readJSONSync(p);
+            plugin._updatedVersion = plugin._bowerInfo.version;
         });
 
         return Q.resolve();
@@ -566,7 +618,7 @@ module.exports = function() {
     }
 
     function printUpdateSummary() {
-        logger.log(chalk.bold.cyan('<info>'), 'Operation completed. Update summary:');
+        if (isInteractive) logger.log(chalk.bold.cyan('<info>'), 'Operation completed. Update summary:');
 
         var present = plugins.filter(isPresent);
         var missing = plugins.filter(isMissing);
@@ -583,6 +635,66 @@ module.exports = function() {
             if (a.packageName > b.packageName) return 1;
             return 0;
         };
+
+        if (!isInteractive) {
+            var report = [];
+
+            latest.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'fulfilled',
+                    pluginData: p._bowerInfo
+                });
+            });
+
+            updated.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'fulfilled',
+                    pluginData: p._bowerInfo
+                });
+            });
+
+            // N.B. there will not be any incompatibleConstrained as this results in a rejected promise
+
+            errored.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'rejected',
+                    pluginData: p._bowerInfo,
+                    reason: p._updateError
+                });
+            });
+
+            incompatible.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'rejected',
+                    pluginData: p._bowerInfo,
+                    reason: 'no update available'
+                });
+            });
+
+            untagged.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'rejected',
+                    pluginData: p._bowerInfo,
+                    reason: 'no published releases'
+                });
+            });
+
+            missing.forEach(function(p) {
+                report.push({
+                    name: p.packageName,
+                    status:'rejected',
+                    pluginData: p._bowerInfo,
+                    reason: 'not registered'
+                });
+            });
+
+            return Q.resolve(report);
+        }
 
         logger.log();
 
@@ -681,7 +793,7 @@ module.exports = function() {
                     //console.log(result.updated, result.error ? 'error code: '+result.error.code : 'no error')
                     plugin._wasUpdated = result.updated;
                     if (result.error) plugin._updateError = result.error.code;
-                    renderUpdateProgress();
+                    if (isInteractive) renderUpdateProgress();
                 });
             })
             

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -63,7 +63,7 @@ module.exports = function() {
             installedPlugins = {};
 
             if (!project.isProjectContainsManifestFile()) {
-                return Q.reject({error:Errors.ERROR_COURSE_DIR});
+                return Q.reject(Errors.ERROR_COURSE_DIR);
             }
 
             args = pluginName ? [pluginName] : ['all'];
@@ -251,7 +251,7 @@ module.exports = function() {
             if (isInteractive) {
                 return Q.reject({message:'No valid targets specified (please check spelling and case).'});
             }
-            return Q.reject({error:Errors.ERROR_NOTHING_TO_UPDATE});
+            return Q.reject(Errors.ERROR_NOTHING_TO_UPDATE);
         } else {
             return Q.resolve();
         }
@@ -473,7 +473,7 @@ module.exports = function() {
             return p.packageName;
         });
 
-        return Q.reject({error:Errors.ERROR_UPDATE_INCOMPATIBLE, context:names});
+        return Q.reject(Errors.ERROR_UPDATE_INCOMPATIBLE);
     }
 
     function promptToUpdateIncompatible() {
@@ -651,7 +651,7 @@ module.exports = function() {
                 if (errored.length == 1) {
                     var error = _.clone(Errors.ERROR_UPDATE_ERROR);
 
-                    if (p._updateError) error.msg = p._updateError;
+                    if (p._updateError) error.message = p._updateError;
 
                     return Q.reject(error);
                 }
@@ -686,7 +686,7 @@ module.exports = function() {
             errored.forEach(function(p) {
                 var error = _.clone(Errors.ERROR_UPDATE_ERROR);
 
-                if (p._updateError) error.msg = p._updateError;
+                if (p._updateError) error.message = p._updateError;
 
                 report.push({
                     name: p.packageName,

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -376,7 +376,7 @@ module.exports = function() {
             //console.log('Querying registry for', plugin.packageName, '(' + plugin.version + ')');
             var versionString = plugin._versions ? '#'+plugin._versions[plugin._versionIndex] : '';
             plugin._bowerCmdCount++;
-            bower.commands.info(plugin.packageName+versionString, null, {registry:Constants.getRegistry()}).on('end', onSuccess).on('error', onFail);
+            bower.commands.info(plugin.packageName+versionString, null, {registry:Constants.getRegistry(), cwd:Constants.cwd}).on('end', onSuccess).on('error', onFail);
         } catch(err) {
             onFail();
         }
@@ -794,8 +794,8 @@ module.exports = function() {
     }
 
     function clean() {
-        if (fs.existsSync('bower.json')) {
-            fs.unlinkSync('bower.json');
+        if (fs.existsSync(path.join(Constants.cwd, 'bower.json'))) {
+            fs.unlinkSync(path.join(Constants.cwd, 'bower.json'));
         }
         return Q.resolve();
     }
@@ -812,11 +812,12 @@ module.exports = function() {
                 manifest = _.extend({}, bowerJson, {dependencies:deps});
                 
                 //console.log('manifest\n', JSON.stringify(manifest, null, 4));
-                JsonWriter.writeJSONSync('bower.json', manifest);
+                JsonWriter.writeJSONSync(path.join(Constants.cwd, 'bower.json'), manifest);
                 //console.log(JSON.stringify(JsonLoader.readJSONSync('bower.json'), null, 4));
                 return update(plugin, null, {
-                    directory: path.join(Constants.cwd, 'src', plugin._belongsTo),
+                    directory: path.join('src', plugin._belongsTo),
                     registry: Constants.getRegistry(),
+                    cwd:Constants.cwd,
                     force:true
                 })
                 .then(function (result) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -53,7 +53,7 @@ module.exports = function() {
         apiupdate: function(pluginName, cwd) {
             isInteractive = false;
 
-            if (cwd) process.chdir(cwd);
+            Constants.setCwd(cwd);
 
             clean();
 
@@ -144,7 +144,7 @@ module.exports = function() {
         var theme = discoverNamedGroup('theme');
 
         function discoverNamedGroup(group) {
-            var srcpath = path.join('src', group);
+            var srcpath = path.join(Constants.cwd, 'src', group);
 
             if (!fs.existsSync(srcpath)) return;
 
@@ -520,7 +520,7 @@ module.exports = function() {
         plugins.filter(isPresent).forEach(function(plugin) {
             if (!plugin._wasUpdated) return;
 
-            var p = path.join('src', plugin._belongsTo, plugin.packageName, 'bower.json');
+            var p = path.join(Constants.cwd, 'src', plugin._belongsTo, plugin.packageName, 'bower.json');
 
             plugin._bowerInfo = JsonLoader.readJSONSync(p);
             plugin._updatedVersion = plugin._bowerInfo.version;
@@ -641,6 +641,30 @@ module.exports = function() {
         if (!isInteractive) {
             var report = [];
 
+            if (plugins.length == 1) {
+                var p = plugins[0];
+
+                if (latest.length == 1 || updated.length == 1) {
+                    var bowerPath = path.join(Constants.cwd, 'src', p._belongsTo, p.packageName, 'bower.json');
+                    return Q.resolve(JsonLoader.readJSONSync(bowerPath));
+                }
+                if (errored.length == 1) {
+                    var error = _.clone(Errors.ERROR_UPDATE_ERROR);
+
+                    if (p._updateError) error.msg = p._updateError;
+
+                    return Q.reject(error);
+                }
+                if (incompatible.length == 1) {
+                    return Q.reject(Errors.ERROR_NO_UPDATE);
+                }
+                if (untagged.length == 1) {
+                    return Q.reject(Errors.ERROR_NO_RELEASES);
+                }
+                
+                return Q.reject(Errors.ERROR_NOT_FOUND);
+            }
+
             latest.forEach(function(p) {
                 report.push({
                     name: p.packageName,
@@ -660,11 +684,15 @@ module.exports = function() {
             // N.B. there will not be any incompatibleConstrained as this results in a rejected promise
 
             errored.forEach(function(p) {
+                var error = _.clone(Errors.ERROR_UPDATE_ERROR);
+
+                if (p._updateError) error.msg = p._updateError;
+
                 report.push({
                     name: p.packageName,
                     status:'rejected',
                     pluginData: p._bowerInfo,
-                    reason: p._updateError
+                    reason: error
                 });
             });
 
@@ -673,7 +701,7 @@ module.exports = function() {
                     name: p.packageName,
                     status:'rejected',
                     pluginData: p._bowerInfo,
-                    reason: 'no update available'
+                    reason: Errors.ERROR_NO_UPDATE
                 });
             });
 
@@ -682,7 +710,7 @@ module.exports = function() {
                     name: p.packageName,
                     status:'rejected',
                     pluginData: p._bowerInfo,
-                    reason: 'no published releases'
+                    reason: Errors.ERROR_NO_RELEASES
                 });
             });
 
@@ -691,7 +719,7 @@ module.exports = function() {
                     name: p.packageName,
                     status:'rejected',
                     pluginData: p._bowerInfo,
-                    reason: 'not registered'
+                    reason: Errors.ERROR_NOT_FOUND
                 });
             });
 
@@ -787,7 +815,7 @@ module.exports = function() {
                 JsonWriter.writeJSONSync('bower.json', manifest);
                 //console.log(JSON.stringify(JsonLoader.readJSONSync('bower.json'), null, 4));
                 return update(plugin, null, {
-                    directory: path.join('src', plugin._belongsTo),
+                    directory: path.join(Constants.cwd, 'src', plugin._belongsTo),
                     registry: Constants.getRegistry(),
                     force:true
                 })

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,58 +1,58 @@
 module.exports = {
     ERROR_COURSE_DIR: {
       code: 0,
-      msg: "Commands must be run in an Adapt project directory"
+      message: "Commands must be run in an Adapt project directory"
     },
     ERROR_INCOMPATIBLE_VALID_REQUEST: {
       code: 1,
-      msg: "No compatible version exists (requested version is valid)"
+      message: "No compatible version exists (requested version is valid)"
     },
     ERROR_INCOMPATIBLE_BAD_REQUEST: {
       code: 2,
-      msg: "No compatible version exists (requested version is invalid)"
+      message: "No compatible version exists (requested version is invalid)"
     },
     ERROR_INCOMPATIBLE: {
       code: 3,
-      msg: "No compatible version exists"
+      message: "No compatible version exists"
     },
     ERROR_COMPATIBLE_INC_REQUEST: {
       code: 4,
-      msg: "Incompatible version requested (compatible version exists)"
+      message: "Incompatible version requested (compatible version exists)"
     },
     ERROR_COMPATIBLE_BAD_REQUEST: {
       code: 5,
-      msg: "Requested version is invalid"
+      message: "Requested version is invalid"
     },
     ERROR_UNINSTALL: {
       code: 6,
-      msg: "The plugin could not be uninstalled"
+      message: "The plugin could not be uninstalled"
     },
     ERROR_NOT_FOUND: {
       code: 7,
-      msg: "The plugin could not be found"
+      message: "The plugin could not be found"
     },
     ERROR_NOTHING_TO_UPDATE: {
       code: 8,
-      msg: "Could not resolve any plugins to update"
+      message: "Could not resolve any plugins to update"
     },
     ERROR_UPDATE_INCOMPATIBLE: {
       code: 9,
-      msg: "Incompatible update requested"
+      message: "Incompatible update requested"
     },
     ERROR_INSTALL_ERROR: {
       code: 10,
-      msg: "Unknown installation error"
+      message: "Unknown installation error"
     },
     ERROR_UPDATE_ERROR: {
       code: 11,
-      msg: "Unknown update error"
+      message: "Unknown update error"
     },
     ERROR_NO_RELEASES: {
       code: 12,
-      msg: "No published releases"
+      message: "No published releases"
     },
     ERROR_NO_UPDATE: {
       code: 13,
-      msg: "No update available"
+      message: "No update available"
     }
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,42 @@
+module.exports = {
+    ERROR_COURSE_DIR: {
+      code: 0,
+      msg: "Commands must be run in an Adapt project directory"
+    },
+    ERROR_INCOMPATIBLE_VALID_REQUEST: {
+      code: 1,
+      msg: "No compatible version exists (requested version is valid)"
+    },
+    ERROR_INCOMPATIBLE_BAD_REQUEST: {
+      code: 2,
+      msg: "No compatible version exists (requested version is invalid)"
+    },
+    ERROR_INCOMPATIBLE: {
+      code: 3,
+      msg: "No compatible version exists"
+    },
+    ERROR_COMPATIBLE_INC_REQUEST: {
+      code: 4,
+      msg: "Incompatible version requested (compatible version exists)"
+    },
+    ERROR_COMPATIBLE_BAD_REQUEST: {
+      code: 5,
+      msg: "Requested version is invalid"
+    },
+    ERROR_UNINSTALL: {
+      code: 6,
+      msg: "The plugin could not be uninstalled"
+    },
+    ERROR_NOT_FOUND: {
+      code: 7,
+      msg: "The plugin could not be found"
+    },
+    ERROR_NOTHING_TO_UPDATE: {
+      code: 8,
+      msg: "Could not resolve any plugins to update"
+    },
+    ERROR_UPDATE_INCOMPATIBLE: {
+      code: 9,
+      msg: "Incompatible update requested"
+    }
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,5 +38,21 @@ module.exports = {
     ERROR_UPDATE_INCOMPATIBLE: {
       code: 9,
       msg: "Incompatible update requested"
+    },
+    ERROR_INSTALL_ERROR: {
+      code: 10,
+      msg: "Unknown installation error"
+    },
+    ERROR_UPDATE_ERROR: {
+      code: 11,
+      msg: "Unknown update error"
+    },
+    ERROR_NO_RELEASES: {
+      code: 12,
+      msg: "No published releases"
+    },
+    ERROR_NO_UPDATE: {
+      code: 13,
+      msg: "No update available"
     }
 }

--- a/lib/promise/install.js
+++ b/lib/promise/install.js
@@ -8,7 +8,7 @@ module.exports = function install (plugin, config) {
     var deferred = Q.defer();
 
     // (reliably) remove the plugin first
-    rimraf(path.join(config.directory, plugin.packageName), {disableGlob:true}, doInstall);
+    rimraf(path.join(config.cwd || '.', config.directory, plugin.packageName), {disableGlob:true}, doInstall);
 
     function doInstall(err) {
         if (err) {

--- a/lib/promise/uninstallPackage.js
+++ b/lib/promise/uninstallPackage.js
@@ -6,7 +6,7 @@ module.exports = function uninstall (plugin, config) {
 
     bower.commands.uninstall([plugin.toString()], {}, config)
     .on('end', function(uninstalled) {
-        deferred.resolve(!!uninstalled);
+        uninstalled.hasOwnProperty(plugin.toString()) ? deferred.resolve() : deferred.reject();
     })
     .on('error', function (err) {
         deferred.reject(err);


### PR DESCRIPTION
@chris-steele kindly put the work in earlier this year to expose some of the CLI's commands as an API.

The rewrite of the authoring tool utilises this API.

This PR implements the first three commands from this [page](https://github.com/adapt-security/adapt-authoring/wiki/CLI-requirements).