### PR TITLE
Add logic for compatible newer (pre-release) tags

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -266,6 +266,8 @@ module.exports = function (dependencies) {
         var compatibleWithOldIncompatibleConstraint = present.filter(isCompatibleWithOldIncompatibleConstraint);
         // a compatible version exists but the user requested an older version that is compatible (prompt for (r)equested, (l)atest compatible or (s)kip)
         var compatibleWithOldCompatibleConstraint = present.filter(isCompatibleWithOldCompatibleConstraint);
+        // a compatible version exists but the user requested a newer version that is compatible (prompt for (r)equested, (l)atest compatible or (s)kip)
+        var compatibleWithNewCompatibleConstraint = present.filter(isCompatibleWithNewCompatibleConstraint);
         // a compatible version exists but the user gave a bad constraint (prompt for (c)ompatible or (s)kip)
         var compatibleWithBadConstraint = present.filter(isCompatibleWithBadConstraint);
         // a compatible version exists but user has requested a valid version that is later than the latest compatible version (prompt for (r)equested, (l)atest compatible or (s)kip)
@@ -299,6 +301,10 @@ module.exports = function (dependencies) {
                 p.markRequestedForInstallation();
             });
 
+            compatibleWithNewCompatibleConstraint.forEach(function(p) {
+                p.markRequestedForInstallation();
+            });
+
             return Q.resolve();
         }
 
@@ -315,6 +321,8 @@ module.exports = function (dependencies) {
         add(compatibleWithOldIncompatibleConstraint, 'An older incompatible version has been requested for the following plugins:', getPrompt_compatibleWithOldIncompatibleConstraint);
 
         add(compatibleWithOldCompatibleConstraint, 'A compatible but older version has been requested for the following plugins:', getPrompt_compatibleWithOldCompatibleConstraint);
+
+        add(compatibleWithNewCompatibleConstraint, 'A compatible but newer version has been requested for the following plugins:', getPrompt_compatibleWithNewCompatibleConstraint);
         
         add(compatibleWithBadConstraint, 'An invalid constraint was given but a compatible version exists for the following plugins:', getPrompt_compatibleWithBadConstraint);
 
@@ -440,6 +448,38 @@ module.exports = function (dependencies) {
     }
 
     function getPrompt_compatibleWithOldCompatibleConstraint(p) {
+        return createPromptTask({
+            message: chalk.white(p.packageName),
+            choices: [
+                {
+                    name: `requested version [${p._resolvedConstraint}]`,
+                    value: 'r'
+                },
+                {
+                    name: `latest compatible version [${p._latestCompatibleVersion}]`,
+                    value: 'l'
+                },
+                {
+                    name: 'skip',
+                    value: 's'
+                }
+            ],
+            type: 'list',
+            default: 's',
+            onlyRejectOnError: true
+        })
+        .then(function (result) {
+            var installRequested = result === 'r';
+            var installLatestCompatible = result === 'l';
+
+            if (installRequested) p.markRequestedForInstallation();
+            if (installLatestCompatible) p.markLatestCompatibleForInstallation();
+
+            return Q.resolve();
+        });
+    }
+
+    function getPrompt_compatibleWithNewCompatibleConstraint(p) {
         return createPromptTask({
             message: chalk.white(p.packageName),
             choices: [
@@ -770,6 +810,10 @@ module.exports = function (dependencies) {
         //
         // the last element determines if the constraint specified version(s) greater than the latest compatible version
         return isCompatible(p) && isConstrained(p) && isGoodConstraint(p) && !isConstraintCompatible(p) && semver.gt(semver.maxSatisfying(p._versions, p.version), p._latestCompatibleVersion);
+    }
+
+    function isCompatibleWithNewCompatibleConstraint(p) {
+        return isCompatible(p) && isConstrained(p) && isGoodConstraint(p) && isConstraintCompatible(p) && semver.gt(semver.maxSatisfying(p._versions, p.version), p._latestCompatibleVersion);
     }
 
     // simple filters


### PR DESCRIPTION
Resolves #139.

Fun fact: this functionality is already in use by the unreleased authoring tool.

As usual, not going for a syntactical refactor; the code style has been copied and modified from existing functions <img src=https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/whatsapp/273/smiling-face-with-tear_1f972.png height=20 width=20>.