### PR TITLE
Fix: Remove process.exit from uncaught exception

### DIFF
--- a/lib/econnreset.js
+++ b/lib/econnreset.js
@@ -4,5 +4,4 @@ process.on('uncaughtException', (error, origin) => {
   console.error('UNCAUGHT EXCEPTION')
   console.error(error)
   console.error(origin)
-  process.exit(1)
 })


### PR DESCRIPTION
#169 

### Fix
* Remove process.exit from uncaught exception handler
