### PR TITLE
Fix: Pass semverOptions to satisfies in Plugin.hasValidRequestVersion

### DIFF
--- a/lib/integration/Plugin.js
+++ b/lib/integration/Plugin.js
@@ -166,7 +166,7 @@ export default class Plugin {
       ? semver.validRange(this.requestedVersion, semverOptions) &&
         (this.isVersioned
           ? semver.maxSatisfying(this.sourceVersions, this.requestedVersion, semverOptions) !== null
-          : semver.satisfies(this.latestSourceVersion, this.requestedVersion)
+          : semver.satisfies(this.latestSourceVersion, this.requestedVersion, semverOptions)
         )
       : null
   }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
https://github.com/adaptlearning/adapt-cli/issues/183