### PR TITLE
Fix: target to use packageName rather than name on install (#196)

### DIFF
--- a/lib/integration/Target.js
+++ b/lib/integration/Target.js
@@ -161,7 +161,7 @@ export default class Target extends Plugin {
     const pluginTypeFolder = await this.getTypeFolder()
     if (this.isLocalSource) {
       await fs.ensureDir(path.resolve(this.cwd, 'src', pluginTypeFolder))
-      const pluginPath = path.resolve(this.cwd, 'src', pluginTypeFolder, this.name)
+      const pluginPath = path.resolve(this.cwd, 'src', pluginTypeFolder, this.packageName)
       await fs.rm(pluginPath, { recursive: true, force: true })
       await fs.copy(this.sourcePath, pluginPath, { recursive: true })
       const bowerJSON = await fs.readJSON(path.join(pluginPath, 'bower.json'))
@@ -177,7 +177,7 @@ export default class Target extends Plugin {
       const repoDetails = await this.getRepositoryUrl()
       if (!repoDetails) throw new Error('Error: Plugin repository url could not be found.')
       await fs.ensureDir(path.resolve(this.cwd, 'src', pluginTypeFolder))
-      const pluginPath = path.resolve(this.cwd, 'src', pluginTypeFolder, this.name)
+      const pluginPath = path.resolve(this.cwd, 'src', pluginTypeFolder, this.packageName)
       await fs.rm(pluginPath, { recursive: true, force: true })
       const url = repoDetails.url.replace(/^git:\/\//, 'https://')
       try {
@@ -206,7 +206,7 @@ export default class Target extends Plugin {
     }
     // bower install
     const outputPath = path.join(this.cwd, 'src', pluginTypeFolder)
-    const pluginPath = path.join(outputPath, this.name)
+    const pluginPath = path.join(outputPath, this.packageName)
     try {
       await fs.rm(pluginPath, { recursive: true, force: true })
     } catch (err) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#196 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Target to use packageName rather than name on install (fixes #196)


