### PR TITLE
Fix: Logger error and warn output (fixes #198)

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,10 +9,10 @@ export default {
     this.write(args.join(' '))
   },
   warn (...args) {
-    chalk.yellow(...args)
+    this.log(chalk.yellow(...args))
   },
   error (...args) {
-    chalk.red(...args)
+    this.log(chalk.red(...args))
   },
   log (...args) {
     if (this.isLoggingProgress) {


### PR DESCRIPTION
fixes #198 

### Fix
* Logger error and warn output is correctly written to the console
