### PR TITLE
Update: Show current version plus latest compatible version in dry runs (fixes #206)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/lib/integration/PluginManagement/update.js
+++ b/lib/integration/PluginManagement/update.js
@@ -3,7 +3,7 @@ import { eachOfSeries } from 'async'
 import path from 'path'
 import Project from '../Project.js'
 import { createPromptTask } from '../../util/createPromptTask.js'
-import { errorPrinter, packageNamePrinter, versionPrinter, existingVersionPrinter } from './print.js'
+import { errorPrinter, packageNamePrinter, existingVersionPrinter } from './print.js'
 import { eachOfLimitProgress, eachOfSeriesProgress } from '../../util/promises.js'
 /** @typedef {import("../Target.js").default} Target */
 
@@ -189,7 +189,7 @@ function summariseDryRun ({ logger, targets }) {
   summarise(logger, localSources, packageNamePrinter, 'The following plugins were installed from a local source and cannot be updated:')
   summarise(logger, toBeSkipped, packageNamePrinter, 'The following plugins will be skipped:')
   summarise(logger, missing, packageNamePrinter, 'There was a problem locating the following plugins:')
-  summarise(logger, toBeInstalled, versionPrinter, 'The following plugins will be updated:')
+  summarise(logger, toBeInstalled, existingVersionPrinter, 'The following plugins will be updated:')
 }
 
 /**


### PR DESCRIPTION
Fixes #206 

### Fix
* Fix typo in _.github/pull_request_template.md_

### Update
* Show current version plus latest compatible version in dry runs

### Testing
1. Run `adapt update --check`. The version first listed should be the current:

```
adapt-contrib-narrative 7.4.11 (latest compatible version is 7.8.0)
```