### PR TITLE
Update: Change order of adapt create course steps to put branch/tag before course (fix #207)

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -66,16 +66,16 @@ async function confirmOptions ({ logger, type, name, branch }) {
     : 'master'
   const propertySchema = [
     {
-      name: 'name',
-      message: 'name',
-      type: 'input',
-      default: name || DEFAULT_TYPE_NAME[typeSchemaResults.type]
-    },
-    {
       name: 'branch',
       message: 'branch/tag',
       type: 'input',
       default: branch || 'not specified'
+    },
+    {
+      name: 'name',
+      message: 'name',
+      type: 'input',
+      default: name || DEFAULT_TYPE_NAME[typeSchemaResults.type]
     },
     {
       name: 'ready',


### PR DESCRIPTION
Fix #207 

### Update
* Change the order of `adapt create course` steps to put `branch/tag` step before `name` step.

### Testing
Run `adapt create course`. You should see the steps in this order:
```
? type: course
? branch/tag v5.40.6
? name (my-adapt-course)
```