### PR TITLE
Fix: add required spawn parameter for Node on Windows (fixes #211)

### DIFF
--- a/lib/integration/AdaptFramework/npmInstall.js
+++ b/lib/integration/AdaptFramework/npmInstall.js
@@ -11,7 +11,8 @@ export default async function npmInstall ({
     logger?.log(chalk.cyan('installing node dependencies'))
     const npm = spawn((process.platform === 'win32' ? 'npm.cmd' : 'npm'), ['--unsafe-perm', 'install'], {
       stdio: 'inherit',
-      cwd
+      cwd,
+      shell: true
     })
     npm.on('close', code => {
       if (code) return reject(new Error('npm install failed'))


### PR DESCRIPTION
#211 

### Fix
* Add required spawn parameter for Node on Windows