### PR TITLE
Update: Allow versionLimit to be passed to getLatestFrameworkVersion (fixes #240)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -81,7 +81,7 @@ class API {
     // cache state of plugins, as these will be wiped
     const plugins = (await new Project({ cwd }).getInstallTargets())
       .map(p => p.isLocalSource ? p.sourcePath : `${p.name}@${p.requestedVersion}`)
-    
+
     await this.installFramework({ version, repository, cwd, logger })
     // restore plugins
     await this.installPlugins({ plugins, cwd, logger })
@@ -93,11 +93,11 @@ class API {
    * @returns {string}
    */
   getCurrentFrameworkVersion ({
-    cwd = process.cwd(),
+    cwd = process.cwd()
   } = {}) {
     return new Project({ cwd }).version
   }
-  
+
   /**
    * @param {Object} options
    * @param {Object} [options.repository=ADAPT_FRAMEWORK] The github repository url

--- a/lib/api.js
+++ b/lib/api.js
@@ -100,13 +100,15 @@ class API {
 
   /**
    * @param {Object} options
+   * @param {string} [options.versionLimit] Semver range to constrain the version lookup
    * @param {Object} [options.repository=ADAPT_FRAMEWORK] The github repository url
    * @returns {string}
    */
   async getLatestFrameworkVersion ({
+    versionLimit,
     repository = ADAPT_FRAMEWORK
   } = {}) {
-    return getLatestVersion({ repository })
+    return getLatestVersion({ versionLimit, repository })
   }
 
   /**


### PR DESCRIPTION
https://github.com/adaptlearning/adapt-cli/issues/240

### Update
* Allow the `versionLimit` semver range parameter to be passed through to `getLatestVersion` from the public `getLatestFrameworkVersion` API method, enabling callers to constrain which framework version is returned.

### Testing
1. Call `api.getLatestFrameworkVersion({ versionLimit: '>=5.0.0 <6.0.0' })` and verify it returns a version within the specified range
2. Call `api.getLatestFrameworkVersion()` without `versionLimit` and verify it still returns the latest version (no regression)