### PR TITLE
Fix: Prevent stray root bower.json from duplicating plugins on install (fixes #235)

### DIFF
--- a/lib/integration/Plugin.js
+++ b/lib/integration/Plugin.js
@@ -351,7 +351,7 @@ export default class Plugin {
 
   /**
    * Infer plugin type from the installed project path.
-   * e.g. src/menu/adapt-contrib-boxMenu → 'menu'
+   * e.g. src/menu/adapt-contrib-boxMenu -> 'menu'
    * @returns {string|null}
    */
   getTypeFromProjectPath () {

--- a/lib/integration/Plugin.js
+++ b/lib/integration/Plugin.js
@@ -335,6 +335,8 @@ export default class Plugin {
    */
   async getType () {
     if (this._type) return this._type
+    const pathType = this.getTypeFromProjectPath()
+    if (pathType) return (this._type = pathType)
     const info = await this.getInfo()
     if (!info) return null
     const foundAttributeType = PLUGIN_TYPES.find(type => info[type])
@@ -345,6 +347,20 @@ export default class Plugin {
       })
       .filter(Boolean)[0]
     return (this._type = foundAttributeType || foundKeywordType || PLUGIN_DEFAULT_TYPE)
+  }
+
+  /**
+   * Infer plugin type from the installed project path.
+   * e.g. src/menu/adapt-contrib-boxMenu → 'menu'
+   * @returns {string|null}
+   */
+  getTypeFromProjectPath () {
+    if (!this.projectPath) return null
+    const folderToType = Object.fromEntries(
+      Object.entries(PLUGIN_TYPE_FOLDERS).map(([type, folder]) => [folder, type])
+    )
+    const parentFolder = path.basename(path.dirname(this.projectPath))
+    return folderToType[parentFolder] || null
   }
 
   async getTypeFolder () {

--- a/lib/integration/Plugin.js
+++ b/lib/integration/Plugin.js
@@ -335,8 +335,6 @@ export default class Plugin {
    */
   async getType () {
     if (this._type) return this._type
-    const pathType = this.getTypeFromProjectPath()
-    if (pathType) return (this._type = pathType)
     const info = await this.getInfo()
     if (!info) return null
     const foundAttributeType = PLUGIN_TYPES.find(type => info[type])
@@ -347,20 +345,6 @@ export default class Plugin {
       })
       .filter(Boolean)[0]
     return (this._type = foundAttributeType || foundKeywordType || PLUGIN_DEFAULT_TYPE)
-  }
-
-  /**
-   * Infer plugin type from the installed project path.
-   * e.g. src/menu/adapt-contrib-boxMenu -> 'menu'
-   * @returns {string|null}
-   */
-  getTypeFromProjectPath () {
-    if (!this.projectPath) return null
-    const folderToType = Object.fromEntries(
-      Object.entries(PLUGIN_TYPE_FOLDERS).map(([type, folder]) => [folder, type])
-    )
-    const parentFolder = path.basename(path.dirname(this.projectPath))
-    return folderToType[parentFolder] || null
   }
 
   async getTypeFolder () {

--- a/lib/integration/PluginManagement/install.js
+++ b/lib/integration/PluginManagement/install.js
@@ -97,6 +97,12 @@ async function loadPluginData ({ logger, project, targets }) {
   logger?.log(`${chalk.bold.cyan('<info>')} Getting plugin info 100% complete`)
   await eachOfLimitProgress(
     targets,
+    target => target.fetchProjectInfo(),
+    percentage => logger?.logProgress?.(`${chalk.bold.cyan('<info>')} Checking installed plugins ${percentage}% complete`)
+  )
+  logger?.log(`${chalk.bold.cyan('<info>')} Checking installed plugins 100% complete`)
+  await eachOfLimitProgress(
+    targets,
     target => target.findCompatibleVersion(frameworkVersion),
     percentage => logger?.logProgress?.(`${chalk.bold.cyan('<info>')} Finding compatible source versions ${percentage}% complete`)
   )

--- a/lib/integration/Target.js
+++ b/lib/integration/Target.js
@@ -122,6 +122,7 @@ export default class Target extends Plugin {
 
   markInstallable () {
     if (!this.isApplyLatestCompatibleVersion && !(this.isLocalSource && this.latestSourceVersion)) return
+    if (this.projectVersion === this.matchedVersion) return
     this.versionToApply = this.matchedVersion
   }
 

--- a/lib/integration/Target.js
+++ b/lib/integration/Target.js
@@ -161,12 +161,17 @@ export default class Target extends Plugin {
   /**
    * Install a plugin via bower into outputPath. Runs from an isolated working
    * directory so an ambient project bower.json cannot inject its own
-   * dependencies into the install directory (fixes #235).
+   * dependencies into the install directory (fixes #235). The project .bowerrc
+   * is copied across so registry, proxy and other bower settings are preserved.
    * @param {string} pluginNameVersion e.g. adapt-contrib-media@7.0.6
    * @param {string} outputPath absolute path to the plugin type folder
    */
   async bowerInstall (pluginNameVersion, outputPath) {
     const isolatedCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'adapt-cli-'))
+    const bowerrcPath = path.join(this.cwd, '.bowerrc')
+    if (await fs.pathExists(bowerrcPath)) {
+      await fs.copy(bowerrcPath, path.join(isolatedCwd, '.bowerrc'))
+    }
     try {
       await new Promise((resolve, reject) => {
         bower.commands.install([pluginNameVersion], null, {

--- a/lib/integration/Target.js
+++ b/lib/integration/Target.js
@@ -4,6 +4,7 @@ import { exec } from 'child_process'
 import semver from 'semver'
 import fs from 'fs-extra'
 import path from 'path'
+import os from 'os'
 import { ADAPT_ALLOW_PRERELEASE } from '../util/constants.js'
 import Plugin from './Plugin.js'
 /** @typedef {import("./Project.js").default} Project */
@@ -157,6 +158,34 @@ export default class Target extends Plugin {
     this.versionToApply = this.projectVersion
   }
 
+  /**
+   * Install a plugin via bower into outputPath. Runs from an isolated working
+   * directory so an ambient project bower.json cannot inject its own
+   * dependencies into the install directory (fixes #235).
+   * @param {string} pluginNameVersion e.g. adapt-contrib-media@7.0.6
+   * @param {string} outputPath absolute path to the plugin type folder
+   */
+  async bowerInstall (pluginNameVersion, outputPath) {
+    const isolatedCwd = await fs.mkdtemp(path.join(os.tmpdir(), 'adapt-cli-'))
+    try {
+      await new Promise((resolve, reject) => {
+        bower.commands.install([pluginNameVersion], null, {
+          directory: outputPath,
+          cwd: isolatedCwd,
+          registry: this.BOWER_REGISTRY_CONFIG
+        })
+          .on('end', resolve)
+          .on('error', err => {
+            err = new Error(`Bower reported ${err}`)
+            this._error = err
+            reject(err)
+          })
+      })
+    } finally {
+      await fs.rm(isolatedCwd, { recursive: true, force: true })
+    }
+  }
+
   async install ({ clone = false } = {}) {
     const logger = this.logger
     const pluginTypeFolder = await this.getTypeFolder()
@@ -213,20 +242,7 @@ export default class Target extends Plugin {
     } catch (err) {
       throw new Error(`There was a problem writing to the target directory ${pluginPath}`)
     }
-    await new Promise((resolve, reject) => {
-      const pluginNameVersion = `${this.packageName}@${this.versionToApply}`
-      bower.commands.install([pluginNameVersion], null, {
-        directory: outputPath,
-        cwd: this.cwd,
-        registry: this.BOWER_REGISTRY_CONFIG
-      })
-        .on('end', resolve)
-        .on('error', err => {
-          err = new Error(`Bower reported ${err}`)
-          this._error = err
-          reject(err)
-        })
-    })
+    await this.bowerInstall(`${this.packageName}@${this.versionToApply}`, outputPath)
     const bowerJSON = await fs.readJSON(path.join(pluginPath, 'bower.json'))
     bowerJSON.version = bowerJSON.version ?? this.versionToApply;
     await fs.writeJSON(path.join(pluginPath, '.bower.json'), bowerJSON, { spaces: 2, replacer: null })
@@ -244,20 +260,7 @@ export default class Target extends Plugin {
     } catch (err) {
       throw new Error(`There was a problem writing to the target directory ${pluginPath}`)
     }
-    await new Promise((resolve, reject) => {
-      const pluginNameVersion = `${this.packageName}@${this.matchedVersion}`
-      bower.commands.install([pluginNameVersion], null, {
-        directory: outputPath,
-        cwd: this.cwd,
-        registry: this.BOWER_REGISTRY_CONFIG
-      })
-        .on('end', resolve)
-        .on('error', err => {
-          err = new Error(`Bower reported ${err}`)
-          this._error = err
-          reject(err)
-        })
-    })
+    await this.bowerInstall(`${this.packageName}@${this.matchedVersion}`, outputPath)
     this.preUpdateProjectVersion = this.projectVersion
     this._projectInfo = null
     await this.fetchProjectInfo()


### PR DESCRIPTION
Fixes #235

### Fix
* Install each plugin from an isolated working directory so an ambient (legacy) root _bower.json_ cannot inject its own dependencies into the install directory. This is the actual cause of #235: a stale _bower.json_ (`"name": "manifest"`), left over from the old grunt/bower toolchain and never removed, pinned `adapt-contrib-boxMenu@7.1.0`. Bower installed that manifest dependency into whichever type folder the requested plugin used (e.g. `src/components` when installing `adapt-contrib-media`), creating a duplicate copy of boxMenu.

### Update
* Skip reinstalling plugins already at the resolved version (`projectVersion === matchedVersion`), and fetch installed-plugin info during install so that comparison is available. Reduces redundant reinstalls on a no-arg `adapt install`.

### Testing

**Setup**

1. Start from a fresh framework project (e.g. 5.56.2) with the default plugins installed (run `adapt install` once), so `adapt-contrib-boxMenu` is present in `src/menu/`.
2. Add a legacy root _bower.json_ at the project root:

```
{
    "name": "manifest",
    "dependencies": {
        "adapt-contrib-boxMenu": "7.1.0"
    }
}
```

**Reproduce the bug (current published CLI / `master`)**

3. Run `adapt install adapt-contrib-media`.
4. Observe: `adapt-contrib-boxMenu@7.1.0` is duplicated into `src/components/`, alongside the correct copy still in `src/menu/`.

**Verify the fix (this PR, `issue/235`)**

5. Delete the duplicate `src/components/adapt-contrib-boxMenu`, leaving the root _bower.json_ in place.
6. Run `adapt install adapt-contrib-media` again.
7. Confirm `adapt-contrib-media` installs to `src/components/` and `adapt-contrib-boxMenu` is NOT duplicated there.
8. Run `adapt install` (no args) and confirm already-current plugins are skipped rather than reinstalled.