### PR TITLE
Fix: surface the failing grunt task/error instead of the whole build transcript

### DIFF
--- a/lib/integration/AdaptFramework/build.js
+++ b/lib/integration/AdaptFramework/build.js
@@ -28,10 +28,17 @@ export default async function adaptBuild ({
     ].filter(Boolean).join(' ');
     exec(cmd, { cwd }, (error, stdout, stderr) => {
       if(error || stderr) {
-        const matches = stdout.match(/>> Error:\s(.+)\s/);
+        // Surface the salient failure rather than the whole grunt transcript:
+        // a '>> Error:' task message, else a bare 'Error:' line (e.g. a rollup
+        // load failure from the javascript task), else the failing-task warning.
+        // Fall back to the full stdout only when none of those are present.
+        const matches = stdout.match(/>> Error:\s(.+)/) ||
+          stdout.match(/^Error:\s(.+)/m) ||
+          stdout.match(/(Warning: Task .+ failed)/);
         const e = new Error('grunt tasks failed')
         e.cmd = cmd;
         e.raw = matches?.[1] ?? stdout;
+        e.stdout = stdout;
         e.source = error;
         e.stderr = stderr;
         return reject(e)


### PR DESCRIPTION
### Fix
* When a grunt build task fails, `adaptBuild` rejected with the **entire grunt transcript** as the error message (the `>> Error:` regex only matched grunt's own task warnings, so anything else — e.g. a rollup "Could not load …" failure from the `javascript` task, which prints a bare `Error:` line — fell through to dumping all of stdout). It now extracts just the salient failure: a `>> Error:` task message, else a bare `Error:` line, else the failing-task `Warning: Task "…" failed` line, falling back to full stdout only when none is present. The full transcript is preserved on `error.stdout` for debugging.

### Testing
1. Run a build whose `javascript`/rollup task fails (e.g. a module import that can't be resolved).
2. The rejected error's `.raw` is now the concise root-cause line instead of the whole grunt transcript; `.stdout` still contains the full log.
